### PR TITLE
Implemented the api for fetching list of tasks that are already executed

### DIFF
--- a/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
@@ -426,7 +426,6 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                 .setBody(constant(null));
 
     }
-<<<<<<< HEAD
 
     private JSONObject getProcessVariable(Long processInstanceKey) throws IOException {
         TermsAggregationBuilder valueAgg = AggregationBuilders.terms("value")
@@ -500,6 +499,4 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
     private QueryBuilder getMatchPhraseQueryBuilder(String key, String valueToMatch) {
         return QueryBuilders.matchPhraseQuery(key, valueToMatch);
     }
-=======
->>>>>>> 9b0af3d (Unused getMatchPhraseQueryBuilder removed)
 }


### PR DESCRIPTION
Implemented the API for fetching the list of tasks that are already completed, by the `processDefinitionKey`.

*Sample request*
```localhost:5000/channel/task/2251799813686414```

*Sample response*
```JSON
{
  "tasks": []
}
```