### PR TITLE
Release mifos-v2.0.0: Java 17 migration, Spring Boot 2.6.2, Mifos JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,155 +1,119 @@
 version: 2.1
-orbs:
-  docker-buildx: devarsh/docker-buildx-orb@0.1.1
+
+# Master CircleCI config template for PHEE Java components.
+# Distributed to all repos by java_version_config_updater.py.
+# Template variables substituted by the script:
+#   cimg/openjdk:17.0.17  - e.g. cimg/openjdk:17.0
+#   ./gradlew checkstyleMain         - ./gradlew checkstyleMain (present or commented out)
+
 executors:
-  docker-executor:
+  java-executor:
+    # cimg/openjdk is built on cimg/base which includes Docker CLI.
+    # No separate Docker CLI install step needed.
+    # The executor JDK is only used to compile the JAR — the final Docker
+    # image base is set independently in each repo's Dockerfile.
     docker:
-      - image: eclipse-temurin:17-jdk
+      - image: cimg/openjdk:17.0.17
+    environment:
+      JVM_OPTS: -Xmx512m
+      TERM: dumb
+
+commands:
+  common-setup:
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - run:
+          name: Set lowercase image name vars
+          # tr used for POSIX compatibility; Bash 4+ alternative: ${VAR,,}
+          command: |
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+      - run:
+          name: Install Docker Buildx
+          command: |
+            BUILDX_VERSION="v0.14.1"
+            if docker buildx version 2>/dev/null | grep -q "$BUILDX_VERSION"; then
+              echo "Docker Buildx $BUILDX_VERSION already present"
+            else
+              mkdir -vp ~/.docker/cli-plugins/
+              curl --silent -L \
+                "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64" \
+                -o ~/.docker/cli-plugins/docker-buildx
+              chmod a+x ~/.docker/cli-plugins/docker-buildx
+              docker buildx version
+            fi
+            docker context create buildcontext 2>/dev/null || true
+            docker buildx create --name multiarch --driver docker-container --use buildcontext 2>/dev/null \
+              || docker buildx use multiarch
+            docker buildx inspect --bootstrap
+
 jobs:
   build_and_push_tag_image:
-    executor: docker-executor
-    environment:
-      JVM_OPTS: -Xmx512m
-      TERM: dumb
+    executor: java-executor
     steps:
-      - checkout
-      - setup_remote_docker:
-          version: 20.10.24
+      - common-setup
       - run:
-          name: Set Lowercase Docker Image Vars
-          # Using tr for POSIX compatibility, could use ${VAR,,} with Bash 4+
-          command: |
-            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
-            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
-            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
-            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
-      - run:
-          name: Install Docker CLI
-          command: |
-            apt-get update
-            apt-get install -y curl ca-certificates gnupg
-            install -m 0755 -d /etc/apt/keyrings
-            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-            chmod a+r /etc/apt/keyrings/docker.asc
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-            apt-get update
-            apt-cache madison docker-ce-cli | grep 20.10
-            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
-      - docker-buildx/install
-      # - run:
-      #     name: Check if Docker image tag exists
-      #     command: |
-      #       IMAGE_TAG=$CIRCLE_TAG
-      #       # Using lowercase variables defined above
-      #       IMAGE_NAME="$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
-      #       echo "Checking for Docker image: $IMAGE_NAME:$IMAGE_TAG"
-      #       # Ensure DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD are set in your CircleCI Context or Project Environment Variables
-      #       if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$IMAGE_TAG" > /dev/null; then
-      #         echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub for image $IMAGE_NAME."
-      #         circleci-agent step halt
-      #       else
-      #         echo "Tag $IMAGE_TAG does not exist for image $IMAGE_NAME. Proceeding with build."
-      #       fi
-      - run:
-          name: Build Application
+          name: Build application
           command: ./gradlew bootJar
-      - docker-buildx/build-and-push:
-          # Using lowercase variables defined above
-          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
-          tag: "$CIRCLE_TAG"
-          # Add dockerhub credentials if needed
-          # dockerhub-username: "$DOCKERHUB_USERNAME"
-          # dockerhub-password: "$DOCKERHUB_PASSWORD"
+      - run:
+          name: Build and push multi-arch image (linux/amd64 + linux/arm64)
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker buildx build \
+              --push \
+              --platform linux/amd64,linux/arm64 \
+              -t "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER:$CIRCLE_TAG" \
+              .
+
   build_and_push_branch_image:
-    executor: docker-executor
-    environment:
-      JVM_OPTS: -Xmx512m
-      TERM: dumb
+    executor: java-executor
     steps:
-      - checkout
-      - setup_remote_docker:
-          version: 20.10.24
+      - common-setup
       - run:
-          name: Set Lowercase Docker Image Vars
-          command: |
-            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
-            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
-            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
-            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
-      - run:
-          name: Install Docker CLI
-          command: |
-            apt-get update
-            apt-get install -y curl ca-certificates gnupg
-            install -m 0755 -d /etc/apt/keyrings
-            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-            chmod a+r /etc/apt/keyrings/docker.asc
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-            apt-get update
-            apt-cache madison docker-ce-cli | grep 20.10
-            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
-      - docker-buildx/install
-      - run:
-          name: Build Application
+          name: Build application
           command: |
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
       - run:
-          name: Sanitize Branch Name
+          name: Sanitize branch name and set commit tag
           command: |
-            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/[^a-zA-Z0-9.-]/-/g' | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV # Also ensure branch tag is lowercase
-      # First build and push with branch-latest tag
-      - docker-buildx/build-and-push:
-          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
-          tag: "${SANITIZED_BRANCH}-latest"
-      # Then build and push with branch-version tag
-      - docker-buildx/build-and-push:
-          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
-          tag: "${SANITIZED_BRANCH}"
-          # Add dockerhub credentials if needed
-          # dockerhub-username: "$DOCKERHUB_USERNAME"
-          # dockerhub-password: "$DOCKERHUB_PASSWORD"
+            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/[^a-zA-Z0-9.-]/-/g' | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export SHORT_SHA=$(echo $CIRCLE_SHA1 | cut -c1-7)" >> $BASH_ENV
+      - run:
+          name: Build and push multi-arch image (linux/amd64 + linux/arm64)
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            # Two tags per build:
+            #   branch-latest  — mutable, always the most recent build on this branch
+            #   branch-SHA     — immutable, traceable to a specific commit
+            docker buildx build \
+              --push \
+              --platform linux/amd64,linux/arm64 \
+              -t "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER:${SANITIZED_BRANCH}-latest" \
+              -t "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER:${SANITIZED_BRANCH}-${SHORT_SHA}" \
+              .
+
   build_and_push_latest_image:
-    executor: docker-executor
-    environment:
-      JVM_OPTS: -Xmx512m
-      TERM: dumb
+    executor: java-executor
     steps:
-      - checkout
-      - setup_remote_docker:
-          version: 20.10.24
+      - common-setup
       - run:
-          name: Set Lowercase Docker Image Vars
-          command: |
-            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
-            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
-            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
-            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
-      - run:
-          name: Install Docker CLI
-          command: |
-            apt-get update
-            apt-get install -y curl ca-certificates gnupg
-            install -m 0755 -d /etc/apt/keyrings
-            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-            chmod a+r /etc/apt/keyrings/docker.asc
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-            apt-get update
-            apt-cache madison docker-ce-cli | grep 20.10
-            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
-      - docker-buildx/install
-      - run:
-          name: Build Application
+          name: Build application
           command: |
             ./gradlew checkstyleMain
             ./gradlew clean bootJar
-      - docker-buildx/build-and-push:
-          # Using lowercase variables defined above
-          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
-          tag: "latest"
-          # Add dockerhub credentials if needed
-          # dockerhub-username: "$DOCKERHUB_USERNAME"
-          # dockerhub-password: "$DOCKERHUB_PASSWORD"
+      - run:
+          name: Build and push multi-arch image (linux/amd64 + linux/arm64)
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker buildx build \
+              --push \
+              --platform linux/amd64,linux/arm64 \
+              -t "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER:latest" \
+              .
+
 workflows:
   version: 2
   build-and-push-pipeline:
@@ -163,16 +127,16 @@ workflows:
               ignore: /.*/
           context:
             - DOCKER
-      # Build any branch commit (except tags)
+      # Build any branch commit (except config-propagator update branches)
       - build_and_push_branch_image:
           filters:
             tags:
               ignore: /.*/
             branches:
-              only: /.*/
+              ignore: /^ci\/mt-.*/
           context:
             - DOCKER
-      # Build 'latest' only when the branch image succeeds AND it's the main/master branch
+      # Build 'latest' only on main/master, after branch image succeeds
       - build_and_push_latest_image:
           requires:
             - build_and_push_branch_image
@@ -181,6 +145,7 @@ workflows:
               ignore: /.*/
             branches:
               only:
-                - main # Or your primary branch name like 'master'
+                - main
+                - master
           context:
             - DOCKER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: circleci/openjdk:13.0-buster-node-browsers-legacy
+      - image: circleci/openjdk:17.0-buster-node-browsers-legacy
 jobs:
   build_and_push_tag_image:
     executor: docker-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,98 +1,150 @@
 version: 2.1
+orbs:
+  docker-buildx: devarsh/docker-buildx-orb@0.1.1
 executors:
   docker-executor:
     docker:
-      - image: circleci/openjdk:17-buster-node-browsers-legacy
-
+      - image: circleci/openjdk:13.0-buster-node-browsers-legacy
 jobs:
   build_and_push_tag_image:
     executor: docker-executor
     environment:
       JVM_OPTS: -Xmx512m
-      TERM: dumb  
-      GITHUB_TOKEN: ${GITHUB_TOKEN}  # Add the GitHub token as an environment variable
-
+      TERM: dumb
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.24
       - run:
-          name: Build and Push Docker tag Image
+          name: Set Lowercase Docker Image Vars
+          # Using tr for POSIX compatibility, could use ${VAR,,} with Bash 4+
           command: |
-            # Set environment variables
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - docker-buildx/install
+      - run:
+          name: Check if Docker image tag exists
+          command: |
             IMAGE_TAG=$CIRCLE_TAG
-
-            # Check if the Docker image with the same tag already exists in Docker Hub
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/openmf/ph-ee-zeebe-ops/tags/$IMAGE_TAG" > /dev/null; then
-              echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub."
-              exit 0
+            # Using lowercase variables defined above
+            IMAGE_NAME="$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+            echo "Checking for Docker image: $IMAGE_NAME:$IMAGE_TAG"
+            # Ensure DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD are set in your CircleCI Context or Project Environment Variables
+            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$IMAGE_TAG" > /dev/null; then
+              echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub for image $IMAGE_NAME."
+              circleci-agent step halt
+            else
+              echo "Tag $IMAGE_TAG does not exist for image $IMAGE_NAME. Proceeding with build."
             fi
-
-            # Build and tag the Docker image
-            ./gradlew bootJar
-            docker build -t "openmf/ph-ee-zeebe-ops:$IMAGE_TAG" .
-
-            # Push the Docker image to Docker Hub
-            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-            docker push "openmf/ph-ee-zeebe-ops:$IMAGE_TAG"
-
-          # when: always  # The job will be executed even if there's no match for the tag filter
-  
+      - run:
+          name: Build Application
+          command: ./gradlew bootJar
+      - docker-buildx/build-and-push:
+          # Using lowercase variables defined above
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "$CIRCLE_TAG"
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
+  build_and_push_branch_image:
+    executor: docker-executor
+    environment:
+      JVM_OPTS: -Xmx512m
+      TERM: dumb
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.24
+      - run:
+          name: Set Lowercase Docker Image Vars
+          command: |
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - docker-buildx/install
+      - run:
+          name: Build Application
+          command: |
+            # ./gradlew checkstyleMain
+            ./gradlew clean bootJar
+      - run:
+          name: Sanitize Branch Name
+          command: |
+            echo "export SANITIZED_BRANCH=$(echo $CIRCLE_BRANCH | sed 's/[^a-zA-Z0-9.-]/-/g' | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV # Also ensure branch tag is lowercase
+      # First build and push with branch-latest tag
+      - docker-buildx/build-and-push:
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "${SANITIZED_BRANCH}-latest"
+      # Then build and push with branch-version tag
+      - docker-buildx/build-and-push:
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "${SANITIZED_BRANCH}"
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
   build_and_push_latest_image:
     executor: docker-executor
     environment:
       JVM_OPTS: -Xmx512m
       TERM: dumb
-
     steps:
       - checkout
-      # Install Docker to build and push the image
       - setup_remote_docker:
-          version: 20.10.14
-
-      # Build the Docker image
+          version: 20.10.24
       - run:
-          name: Build Docker image
+          name: Set Lowercase Docker Image Vars
           command: |
-            ./gradlew bootJar
-            docker build -t openmf/ph-ee-zeebe-ops:latest .
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-              PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-              PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-              JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-              if [ -z "$JIRA_STORY" ]; then echo "Invalid PR title" && exit 1; else echo "Ticket NO: $JIRA_STORY"; fi
-              docker image tag openmf/$CIRCLE_PR_REPONAME:latest openmf/$CIRCLE_PR_REPONAME:$JIRA_STORY
-            fi
-
-      # Log in to DockerHub using environment variables
+            echo "export DOCKER_ORG_LOWER=$(echo $CIRCLE_PROJECT_USERNAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
+            echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
+            echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - docker-buildx/install
       - run:
-          name: Login to DockerHub
-          command: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
-
-      # Push the Docker image to DockerHub
-      - run:
-          name: Push Docker image to DockerHub
+          name: Build Application
           command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-            docker push openmf/ph-ee-zeebe-ops:latest
-            fi
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-            PR_NUMBER=$(basename $CIRCLE_PULL_REQUEST)
-            PR_TITLE=$(curl -sSL "https://api.github.com/repos/openmf/$CIRCLE_PR_REPONAME/pulls/$PR_NUMBER" | jq -r '.title')
-            JIRA_STORY=$(echo $PR_TITLE | cut -d "[" -f2 | cut -d "]" -f1 | tr '[A-Z]' '[a-z]')
-            docker push openmf/$CIRCLE_PR_REPONAME:${JIRA_STORY}
-            fi
+            # ./gradlew checkstyleMain
+            ./gradlew clean bootJar
+      - docker-buildx/build-and-push:
+          # Using lowercase variables defined above
+          image-name: "$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+          tag: "latest"
+          # Add dockerhub credentials if needed
+          # dockerhub-username: "$DOCKERHUB_USERNAME"
+          # dockerhub-password: "$DOCKERHUB_PASSWORD"
 workflows:
   version: 2
-  build-and-push:
+  build-and-push-pipeline:
     jobs:
+      # Build tags matching vX.Y.Z format
       - build_and_push_tag_image:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+$/  # Match tags in the format v1.2.3
+              only: /^v\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
           context:
-              - DOCKER
+            - DOCKER
+      # Build any branch commit (except tags)
+      - build_and_push_branch_image:
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: /.*/
+          context:
+            - DOCKER
+      # Build 'latest' only when the branch image succeeds AND it's the main/master branch
       - build_and_push_latest_image:
+          requires:
+            - build_and_push_branch_image
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only:
+                - main # Or your primary branch name like 'master'
           context:
-              - DOCKER
-             
+            - DOCKER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: circleci/openjdk:17.0-buster-node-browsers-legacy
+      - image: eclipse-temurin:17-jdk
 jobs:
   build_and_push_tag_image:
     executor: docker-executor
@@ -23,21 +23,33 @@ jobs:
             echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
             echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
             echo "Using Docker Repository: $DOCKER_REPO_LOWER"
-      - docker-buildx/install
       - run:
-          name: Check if Docker image tag exists
+          name: Install Docker CLI
           command: |
-            IMAGE_TAG=$CIRCLE_TAG
-            # Using lowercase variables defined above
-            IMAGE_NAME="$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
-            echo "Checking for Docker image: $IMAGE_NAME:$IMAGE_TAG"
-            # Ensure DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD are set in your CircleCI Context or Project Environment Variables
-            if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$IMAGE_TAG" > /dev/null; then
-              echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub for image $IMAGE_NAME."
-              circleci-agent step halt
-            else
-              echo "Tag $IMAGE_TAG does not exist for image $IMAGE_NAME. Proceeding with build."
-            fi
+            apt-get update
+            apt-get install -y curl ca-certificates gnupg
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update
+            apt-cache madison docker-ce-cli | grep 20.10
+            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
+      - docker-buildx/install
+      # - run:
+      #     name: Check if Docker image tag exists
+      #     command: |
+      #       IMAGE_TAG=$CIRCLE_TAG
+      #       # Using lowercase variables defined above
+      #       IMAGE_NAME="$DOCKER_ORG_LOWER/$DOCKER_REPO_LOWER"
+      #       echo "Checking for Docker image: $IMAGE_NAME:$IMAGE_TAG"
+      #       # Ensure DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD are set in your CircleCI Context or Project Environment Variables
+      #       if curl -s -f -u "$DOCKERHUB_USERNAME":"$DOCKERHUB_PASSWORD" "https://hub.docker.com/v2/repositories/$IMAGE_NAME/tags/$IMAGE_TAG" > /dev/null; then
+      #         echo "Skipping the build and push as the tag $IMAGE_TAG already exists in Docker Hub for image $IMAGE_NAME."
+      #         circleci-agent step halt
+      #       else
+      #         echo "Tag $IMAGE_TAG does not exist for image $IMAGE_NAME. Proceeding with build."
+      #       fi
       - run:
           name: Build Application
           command: ./gradlew bootJar
@@ -64,11 +76,23 @@ jobs:
             echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
             echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
             echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - run:
+          name: Install Docker CLI
+          command: |
+            apt-get update
+            apt-get install -y curl ca-certificates gnupg
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update
+            apt-cache madison docker-ce-cli | grep 20.10
+            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
       - docker-buildx/install
       - run:
           name: Build Application
           command: |
-            # ./gradlew checkstyleMain
+            ./gradlew checkstyleMain
             ./gradlew clean bootJar
       - run:
           name: Sanitize Branch Name
@@ -101,11 +125,23 @@ jobs:
             echo "export DOCKER_REPO_LOWER=$(echo $CIRCLE_PROJECT_REPONAME | tr '[:upper:]' '[:lower:]')" >> $BASH_ENV
             echo "Using Docker Namespace: $DOCKER_ORG_LOWER"
             echo "Using Docker Repository: $DOCKER_REPO_LOWER"
+      - run:
+          name: Install Docker CLI
+          command: |
+            apt-get update
+            apt-get install -y curl ca-certificates gnupg
+            install -m 0755 -d /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+            chmod a+r /etc/apt/keyrings/docker.asc
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+            apt-get update
+            apt-cache madison docker-ce-cli | grep 20.10
+            apt-get install -y docker-ce-cli=5:20.10.24~3-0~debian-bullseye
       - docker-buildx/install
       - run:
           name: Build Application
           command: |
-            # ./gradlew checkstyleMain
+            ./gradlew checkstyleMain
             ./gradlew clean bootJar
       - docker-buildx/build-and-push:
           # Using lowercase variables defined above

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:13
+FROM openjdk:17
 
 COPY build/libs/*.jar ./
 CMD java -jar *.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jdk
 
 COPY build/libs/*.jar ./
 CMD java -jar *.jar

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.6.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id 'checkstyle'
 }
 
 group = 'org.mifos'
@@ -24,6 +25,22 @@ repositories {
 
 ext {
     springBootVersion = '2.6.2'
+}
+
+checkstyle {
+    toolVersion = '10.9.3'
+    configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")
+    ignoreFailures = false
+    maxWarnings = 0
+}
+
+configurations {
+    checkstyle
+}
+
+dependencies {
+    checkstyle 'com.puppycrawl.tools:checkstyle:10.9.3'
+    checkstyle 'com.github.sevntu-checkstyle:sevntu-checks:1.44.1'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,19 @@ plugins {
 
 group = 'org.mifos'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 
 repositories {
     mavenCentral()
-    mavenLocal()
+    // mavenLocal()
     maven {
-        url = uri('https://jfrog.sandbox.fynarfin.io/artifactory/fyn-libs-snapshot')
+        url = uri('https://repo.maven.apache.org/maven2/')
+    }
+    maven {
+        url = uri('https://mifos.jfrog.io/artifactory/phee-gradle-local')
+    }    
+    maven {
+        url = uri('https://mifos.jfrog.io/artifactory/mifosx-gradle-local')
     }
 }
 
@@ -21,7 +27,8 @@ ext {
 }
 
 dependencies {
-    implementation 'org.mifos:ph-ee-connector-common:1.0.0-SNAPSHOT'
+    // implementation 'org.mifos:ph-ee-connector-common:1.0.0-SNAPSHOT'
+    implementation 'org.mifos:ph-ee-connector-common:1.8.1-gazelle'
     implementation 'org.apache.camel.springboot:camel-spring-boot-starter:3.4.0'
     implementation 'org.apache.camel:camel-bean-validator:3.4.0'
     implementation 'org.apache.camel:camel-undertow:3.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.5.5'
+    id 'org.springframework.boot' version '2.6.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
@@ -16,31 +16,42 @@ repositories {
     }
     maven {
         url = uri('https://mifos.jfrog.io/artifactory/phee-gradle-local')
-    }    
+    }
     maven {
         url = uri('https://mifos.jfrog.io/artifactory/mifosx-gradle-local')
     }
 }
 
 ext {
-    springBootVersion = '2.5.5'
+    springBootVersion = '2.6.2'
 }
 
 dependencies {
     // implementation 'org.mifos:ph-ee-connector-common:1.0.0-SNAPSHOT'
     implementation 'org.mifos:ph-ee-connector-common:1.8.1-gazelle'
-    implementation 'org.apache.camel.springboot:camel-spring-boot-starter:3.4.0'
-    implementation 'org.apache.camel:camel-bean-validator:3.4.0'
-    implementation 'org.apache.camel:camel-undertow:3.4.0'
-    implementation 'org.apache.camel.springboot:camel-jackson-starter:3.4.0'
+    
+    // Updated Camel versions compatible with Spring Boot 2.6.2
+    implementation 'org.apache.camel.springboot:camel-spring-boot-starter:3.14.0'
+    implementation 'org.apache.camel:camel-bean-validator:3.14.0'
+    implementation 'org.apache.camel:camel-undertow:3.14.0'
+    implementation 'org.apache.camel.springboot:camel-jackson-starter:3.14.0'
+    
     implementation 'io.camunda:zeebe-client-java:8.1.1'
-    implementation 'io.netty:netty-bom:4.1.65.Final'
+    
+    // Updated Netty version for better compatibility
+    implementation 'io.netty:netty-bom:4.1.72.Final'
+    
+    // Updated Jackson version
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
+    
     implementation 'org.json:json:20211205'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'javax.mail:mail:1.4.7'
+    
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    
+    // Spring Boot starters using the variable
     implementation "org.springframework.boot:spring-boot-starter:$springBootVersion"
     implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
     implementation "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'org.mifos'
-version = '0.0.1-SNAPSHOT'
+version = '2.0.0.mifos-SNAPSHOT'
 sourceCompatibility = '17'
 
 repositories {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="charset" value="UTF-8"/>
+    <property name="severity" value="error"/>
+
+    <!--
+        You can learn more about individual checkstyles at: https://checkstyle.sourceforge.io/
+        Checks related to LineLength and Indentation are only handled by Spotless
+        Checks included in MissingSwitchDefault are handled by ErrorProne
+    -->
+
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/suppressions.xml"/>
+    </module>
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$"/>
+        <property name="message" value="Line has trailing spaces."/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="(?s:\r\n.*)"/>
+        <property name="message" value="File has Windows (CR+LF) instead of UNIX (LF) end of line (EOL) delimiters."/>
+    </module>
+    <module name="SuppressWarningsFilter"/>
+
+
+    <module name="TreeWalker">
+    <module name="ParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$|[a-z]"/>
+            <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidHidingCauseExceptionCheck" />
+    <module name="SuppressWarningsHolder" />
+    <module name="RegexpSinglelineJava">
+            <property name="format" value="System\.(out)|(err)\.print(ln)?\("/>
+            <property name="message" value="Line contains console output."/>
+            <property name="ignoreComments" value="false" />
+        </module>
+        <module name="EqualsHashCode"/>
+        <module name="FinalClass"/>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="FallThrough"/>
+        <module name="IllegalThrows" />
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+        <module name="AvoidStarImport"/>
+        <module name="LeftCurly" />
+         <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="CustomImportOrder">
+            <property name="thirdPartyPackageRegExp" value=".*"/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+        </module>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="ALONE_OR_SINGLELINE"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCertainImportsCheck">
+            <property name="packageNameRegexp" value=".*" />
+            <property name="forbiddenImportsRegexp" value="com.google.common.base.Charsets" />
+            <property name="forbiddenImportsExcludesRegexp" value="" />
+            <message key="forbid.certain.imports" value="Use ''java.nio.charset.StandardCharsets'' instead of ''{0}''" />
+        </module>
+           <module name="OneStatementPerLine"/>
+           <module name="EmptyStatement"/>
+         <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected|ignore"/>
+        </module>
+             <module name="RegexpSinglelineJava">
+            <property name="format" value="\.printStackTrace?\("/>
+            <property name="message" value="Line contains printStacktrace()."/>
+            <property name="ignoreComments" value="false" />
+            </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+            <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+            <!-- No PACKAGE_DEF token, as we like our license header to be glue to "package" statement, to save 1 line screen space -->
+            <property name="tokens" value="IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9_]*)*$"/>
+            <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="OuterTypeFilename"/>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+         <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+          <module name="UpperEll"/>
+          <module name="NeedBraces"/>
+          <module name="MethodParamPad"/>
+          <module name="ArrayTypeStyle"/>
+          <module name="NoLineWrap"/>
+         <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
+        </module>
+          <module name="GenericWhitespace">
+            <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+             <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+             <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="HideUtilityClassConstructor"/>
+          <module name="OneTopLevelClass"/>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+                <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+          <module name="MutableException"/>
+            <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+             value="WhitespaceAround: ''{0}'' is not followed by whitespace."/>
+             <message key="ws.notPreceded"
+             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="RedundantModifier"/>
+        <module name="ParenPad" />
+        <module name="ModifierOrder"/>
+                <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$|[a-z]"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="AvoidNoArgumentSuperConstructorCall"/>
+        <module name="AvoidDoubleBraceInitialization"/>
+<!-- TODO Enable many more checks (go about this one by one, step by step, raise separate PRs fixing and then enforcing):
+
+        <module name="HiddenField">
+            <property name="ignoreAbstractMethods" value="true" />
+            <property name="ignoreConstructorParameter" value="true" />
+            <property name="ignoreSetter" value="true" />
+            <property name="setterCanReturnItsClass" value="true" />
+        </module>
+
+
+        < ! - - TODO Checks for Exception Handling Anti-Patterns - - >
+        <module name="IllegalCatch"/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        <module name="ConstantName" />
+
+
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="4"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+
+
+        <! - - Enable some JavaDoc validation (requires quite a lot of manual clean up work; not a top priority for initial Checkstyle adoption - ->
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadocCheck">
+            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocStyle">
+            < ! - - Do NOT 'scope' this one; any JavaDoc (public/protected/private) IFF present, should be style checked. - - >
+            <property name="checkEmptyJavadoc" value="true" />
+            <property name="tokens" value="ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="SingleLineJavadoc"/>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        < ! - - TODO Enable proper JavaDoc paragraphs (requires removing /** from all license headers) - - >
+        <module name="JavadocParagraph">
+            <property name="allowNewlineParagraph" value="false"/>
+        </module>
+-->
+    </module>
+    <!-- NB, PS: This entire custom Checkstyle configuration originally came from (EPL'd)
+         https://github.com/opendaylight/odlparent/blob/master/checkstyle/src/main/resources/odl_checks.xml
+         (for which it was first created by Michael Vorburger.ch while he worked on that community in 2016-2018).
+         Michael in Jan 2020 copy/pasted this into Apache Fineract (where he has been actively contributing since
+         ca. 2010 when it was still Mifos), where it was then independantly maintained by Apache contributors.    -->
+</module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<!--
+    This file contains suppression rules for Checkstyle checks.
+    Ideally only files that cannot be modified (e.g. third-party code)
+    should be added here. All other violations should be fixed.
+-->
+
+<suppressions>
+    <suppress files="[/\\]build[/\\]generated[/\\]" checks=".*"/>
+<!--    &lt;!&ndash; TODO: fix integration test formatting &ndash;&gt;-->
+    <suppress files="[/\\]integration-tests[/\\]src[/\\]test[/\\]main[/\\]" checks=".*"/>
+</suppressions>

--- a/src/main/java/org/mifos/ops/zeebe/ZeebeOpsApplication.java
+++ b/src/main/java/org/mifos/ops/zeebe/ZeebeOpsApplication.java
@@ -5,6 +5,12 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLContext;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -25,23 +31,16 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.RestClients;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import javax.net.ssl.SSLContext;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-
 @SpringBootApplication
 @Component
 public class ZeebeOpsApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(ZeebeOpsApplication.class);
 
     @Value("${spring.data.elasticsearch.client.reactive.endpoints}")
     private String contactPoint;
@@ -78,7 +77,7 @@ public class ZeebeOpsApplication {
 
         RestClientBuilder builder;
         SSLContext sslContext = null;
-        if(securityEnabled) {
+        if (securityEnabled) {
             final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
             credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
             if (sslVerify) {
@@ -87,7 +86,7 @@ public class ZeebeOpsApplication {
                     sslBuilder = SSLContexts.custom().loadTrustMaterial(null, (x509Certificates, s) -> true);
                     sslContext = sslBuilder.build();
                 } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
-                    e.printStackTrace();
+                    log.error("Error building SSL context", e);
                 }
                 HttpHost httpHost = urlToHttpHost(elasticUrl);
                 SSLContext finalSslContext = sslContext;
@@ -107,7 +106,9 @@ public class ZeebeOpsApplication {
             builder =
                     RestClient.builder(httpHost).setHttpClientConfigCallback(this::setHttpClientConfigCallback);
         }
-        return new RestHighLevelClient(builder);}
+        return new RestHighLevelClient(builder);
+    }
+
     private HttpAsyncClientBuilder setHttpClientConfigCallback(HttpAsyncClientBuilder builder) {
         builder.setDefaultIOReactorConfig(IOReactorConfig.custom().setIoThreadCount(1).build());
         return builder;
@@ -118,7 +119,7 @@ public class ZeebeOpsApplication {
         try {
             uri = new URI(url);
         } catch (URISyntaxException e) {
-            e.printStackTrace();
+            log.error("Error parsing URL: {}", url, e);
         }
 
         return new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());

--- a/src/main/java/org/mifos/ops/zeebe/camel/config/CamelContextConfig.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/config/CamelContextConfig.java
@@ -1,13 +1,12 @@
 package org.mifos.ops.zeebe.camel.config;
 
+import java.util.HashMap;
 import org.apache.camel.CamelContext;
 import org.apache.camel.spi.RestConfiguration;
 import org.apache.camel.spring.boot.CamelContextConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.HashMap;
 
 @Configuration
 public class CamelContextConfig {

--- a/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
@@ -1,11 +1,31 @@
 package org.mifos.ops.zeebe.camel.routes;
 
+import static org.mifos.ops.zeebe.zeebe.ZeebeMessages.OPERATOR_MANUAL_RECOVERY;
+import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.BPMN_PROCESS_ID;
+import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.PROCESS_DEFINITION_KEY;
+import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.PROCESS_INSTANCE_KEY;
+import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.TRANSACTION_ID;
+
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.instance.Definitions;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.activation.DataHandler;
+import javax.mail.internet.MimeBodyPart;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.camunda.bpm.model.xml.instance.DomDocument;
@@ -14,31 +34,20 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.json.JSONArray;
-import org.elasticsearch.client.indices.GetIndexRequest;
 import org.json.JSONObject;
+import org.mifos.connector.common.camel.ErrorHandlerRouteBuilder;
 import org.mifos.ops.zeebe.ZeebeOpsApplication;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.mifos.connector.common.camel.ErrorHandlerRouteBuilder;
-import org.springframework.web.multipart.MultipartFile;
-
-import javax.activation.DataHandler;
-import javax.mail.internet.MimeBodyPart;
-import java.io.*;
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import static org.mifos.ops.zeebe.zeebe.ZeebeMessages.OPERATOR_MANUAL_RECOVERY;
-import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.*;
 
 @Component
 public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
@@ -64,7 +73,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
     private List<String> tenants;
 
     private void removeLastLine(String bpmnFileName) throws IOException {
-        String filePath = "upload/"+bpmnFileName;
+        String filePath = "upload/" + bpmnFileName;
         RandomAccessFile f = new RandomAccessFile(filePath, "rw");
         long length = f.length() - 1;
         byte b;
@@ -72,15 +81,15 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
             length -= 1;
             f.seek(length);
             b = f.readByte();
-        } while(b != 10);
-        f.setLength(length+1);
+        } while (b != 10);
+        f.setLength(length + 1);
         f.close();
 
     }
 
     private List<String> formatBpmn(String bpmnFileName) throws IOException {
         removeLastLine(bpmnFileName);
-        String filePath = "upload/"+bpmnFileName;
+        String filePath = "upload/" + bpmnFileName;
         List<String> uploadingFilePath = new ArrayList<>();
 
         if (!bpmnFileName.contains("DFSPID")) {
@@ -89,7 +98,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
         }
 
         BpmnModelInstance instance = Bpmn.readModelFromFile(new File(filePath));
-        String baseId = bpmnFileName.substring(0, bpmnFileName.indexOf("DFSPID")-1).replace("-", "_");
+        String baseId = bpmnFileName.substring(0, bpmnFileName.indexOf("DFSPID") - 1).replace("-", "_");
 
         for (String tenant: tenants) {
             logger.info("Creating tenant specific: " + tenant);
@@ -102,21 +111,21 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
             processElement.setAttribute("name", tenantSpecificId);
             String fp = String.format("upload/%s.bpmn", tenantSpecificId);
             Bpmn.writeModelToFile(new File(fp), tenantSpecificInstance);
-            formatBpmnWorker(fp,tenant);
+            formatBpmnWorker(fp, tenant);
             Bpmn.validateModel(tenantSpecificInstance);
             uploadingFilePath.add(fp);
             logger.info("Done");
         }
         return uploadingFilePath;
     }
+
     private void formatBpmnWorker(String filePath, String tenant) throws IOException {
         File fileToBeModified = new File(filePath);
         String oldContent = "";
         BufferedReader reader = new BufferedReader(new FileReader(fileToBeModified));
         String line = reader.readLine();
 
-        while (line != null)
-        {
+        while (line != null) {
             oldContent = oldContent + line + System.lineSeparator();
             line = reader.readLine();
         }
@@ -157,7 +166,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                     // file formatting
                     List<String> bpmnFilePaths = formatBpmn(bpmnFileName);
 
-                    for(String path: bpmnFilePaths) {
+                    for (String path: bpmnFilePaths) {
                         // deploying
                         DeploymentEvent deploymentEvent =
                                 zeebeClient.newDeployCommand().addResourceFile(path)
@@ -167,9 +176,9 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                     }
 
                     // deleting bpmn file
-                    File file = new File("upload/"+bpmnFileName);
+                    File file = new File("upload/" + bpmnFileName);
                     file.delete();
-                    logger.info("Deleted file " + "upload/"+bpmnFileName + "after successful deployment");
+                    logger.info("Deleted file " + "upload/" + bpmnFileName + " after successful deployment");
 
                     exchange.getIn().setBody(response.toString());
                     logger.info(response.toString());
@@ -179,8 +188,8 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
          * Cancellation of the process by variable name and value
          *
          * sample request: {
-         * 	"key": "initiatorFspId",
-         * 	"value": "\"ibank-usa\""
+         *   "key": "initiatorFspId",
+         *   "value": "\"ibank-usa\""
          * }
          *
          * sample response: {
@@ -499,7 +508,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                     JSONObject object = new JSONObject(exchange.getIn().getBody(String.class));
                     JSONArray processIds = object.getJSONArray("processId");
 
-                    JSONObject response =cancelProcess(processIds);
+                    JSONObject response = cancelProcess(processIds);
 
                     exchange.getMessage().setBody(response.toString());
                 });
@@ -731,7 +740,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
         JSONArray keyBucket = res.getJSONObject("aggregations").getJSONObject("sterms#worker")
                 .getJSONArray("buckets");
 
-        if(keyBucket.isEmpty()) {
+        if (keyBucket.isEmpty()) {
             throw new Exception("Unable to fetch current state");
         }
 
@@ -751,7 +760,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                 zeebeClient.newCancelInstanceCommand(processId).send().join();
                 success.put(processId);
                 successfullyCancelled.getAndIncrement();
-            }catch (Exception e) {
+            } catch (Exception e) {
                 failed.put(processId);
                 cancellationFailed.getAndIncrement();
                 logger.error("Cancellation of process id " + processId + " failed\n" + e.getMessage());
@@ -781,7 +790,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
                 zeebeClient.newCancelInstanceCommand(processId).send().join();
                 success.put(processId);
                 successfullyCancelled.getAndIncrement();
-            }catch (Exception e) {
+            } catch (Exception e) {
                 failed.put(processId);
                 cancellationFailed.getAndIncrement();
                 logger.error("Cancellation of process id " + processId + " failed\n" + e.getMessage());

--- a/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeMessages.java
+++ b/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeMessages.java
@@ -1,6 +1,6 @@
 package org.mifos.ops.zeebe.zeebe;
 
-public class ZeebeMessages {
+public final class ZeebeMessages {
 
     private ZeebeMessages() {}
 

--- a/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeVariables.java
@@ -1,6 +1,6 @@
 package org.mifos.ops.zeebe.zeebe;
 
-public class ZeebeVariables {
+public final class ZeebeVariables {
 
     private ZeebeVariables() {
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  port: 8080
+  address: 0.0.0.0
+  
 camel:
   server-port: 5000
   springboot:
@@ -27,8 +31,6 @@ logging:
   level:
     root: INFO
 
-
-
 elasticsearch:
   url: "https://ph-ee-elasticsearch:9200/"
   security:
@@ -38,8 +40,10 @@ elasticsearch:
   password: "spmepassword"
 
 management:
-#  server:
-#    port: 5000
+  endpoints:
+    web:
+      exposure:
+        include: health,info
   endpoint:
     health:
       probes:
@@ -48,4 +52,4 @@ management:
         enabled: true
       readiness:
         enabled: true
-#      show-details: always
+


### PR DESCRIPTION
## Summary

This release brings ph-ee-zeebe-ops to version 2.0.0.mifos-SNAPSHOT with Java 17 migration, Spring Boot upgrade, and Mifos JFrog Artifactory integration.

### Key Changes

- **Java 17 migration**: Updated Dockerfile from JDK 13 to `eclipse-temurin:17-jdk`; updated CircleCI config to Java 17
- **Spring Boot 2.6.2**: Upgraded from earlier version; enabled readiness and liveness probes in `application.yml`
- **Mifos JFrog**: Updated `build.gradle` to resolve dependencies from Mifos JFrog Artifactory
- **Code quality**: Added CheckStyle to build and corrected violations
- **Version**: Bumped to `2.0.0.mifos-SNAPSHOT`

### Test Plan

- [ ] Verify zeebe-ops starts correctly and readiness/liveness probes respond
- [ ] Confirm Zeebe workflow operations (list/cancel/resolve incidents) function correctly
- [ ] Confirm CircleCI pipeline passes with Java 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)