### PR TITLE
PHEE-370: Migrate to Spring Boot 3.4 / JDK 21 / Jakarta EE 10 / Camel 4 (via Mifos Platform BOM)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:21-jre
 
 COPY build/libs/*.jar ./
 CMD java -jar *.jar

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,14 @@
 plugins {
-    id 'org.springframework.boot' version '2.6.2'
-    id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.6'
     id 'java'
     id 'checkstyle'
 }
 
 group = 'org.mifos'
 version = '2.0.0.mifos-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenCentral()
@@ -21,10 +22,20 @@ repositories {
     maven {
         url = uri('https://mifos.jfrog.io/artifactory/mifosx-gradle-local')
     }
-}
 
-ext {
-    springBootVersion = '2.6.2'
+    // Mifos Platform BOM + ph-ee-connector-common 2.0.0-SNAPSHOT are consumed
+    // from the local JFrog Artifactory sandbox (Docker Compose in
+    // proposal/local-jfrog/). Swap this host for the production Mifos JFrog
+    // when the official BOM is ready.
+    maven {
+        name = 'LocalJFrog'
+        url = uri('http://localhost:8081/artifactory/mifos-platform-snapshot')
+        allowInsecureProtocol = true
+        credentials {
+            username = findProperty('localJfrog.user') ?: System.getenv('LOCAL_JFROG_USER')
+            password = findProperty('localJfrog.key') ?: System.getenv('LOCAL_JFROG_KEY')
+        }
+    }
 }
 
 checkstyle {
@@ -44,34 +55,35 @@ dependencies {
 }
 
 dependencies {
-    // implementation 'org.mifos:ph-ee-connector-common:1.0.0-SNAPSHOT'
-    implementation 'org.mifos:ph-ee-connector-common:1.8.1-gazelle'
-    
-    // Updated Camel versions compatible with Spring Boot 2.6.2
-    implementation 'org.apache.camel.springboot:camel-spring-boot-starter:3.14.0'
-    implementation 'org.apache.camel:camel-bean-validator:3.14.0'
-    implementation 'org.apache.camel:camel-undertow:3.14.0'
-    implementation 'org.apache.camel.springboot:camel-jackson-starter:3.14.0'
-    
-    implementation 'io.camunda:zeebe-client-java:8.1.1'
-    
-    // Updated Netty version for better compatibility
-    implementation 'io.netty:netty-bom:4.1.72.Final'
-    
-    // Updated Jackson version
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
-    
-    implementation 'org.json:json:20211205'
-    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    // Mifos Platform BOM pins Spring Boot 3.4, Camel 4, Zeebe 8, Jakarta EE 10
+    // and every other shared library version. Do NOT hardcode managed versions.
+    // This is a deployable application (leaf node), so use enforcedPlatform().
+    implementation enforcedPlatform('org.mifos.platform:mifos-platform-bom:1.0.0-SNAPSHOT')
+
+    implementation 'org.mifos:ph-ee-connector-common:2.0.0-SNAPSHOT'
+
+    implementation 'org.apache.camel.springboot:camel-spring-boot-starter'
+    implementation 'org.apache.camel:camel-bean-validator'
+    implementation 'org.apache.camel:camel-undertow'
+    implementation 'org.apache.camel.springboot:camel-jackson-starter'
+
+    implementation 'io.camunda:zeebe-client-java'
+
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    implementation 'org.json:json'
+    // The code uses the legacy ES7 RestHighLevelClient directly (own @Bean, no
+    // Spring Data repositories), so the spring-data-elasticsearch starter was
+    // replaced with the explicit legacy client, pinned via the BOM.
+    implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'javax.mail:mail:1.4.7'
-    
+    // javax.mail:mail 1.4.7 -> Jakarta Mail (Eclipse Angus implementation)
+    implementation 'org.eclipse.angus:angus-mail'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    
-    // Spring Boot starters using the variable
-    implementation "org.springframework.boot:spring-boot-starter:$springBootVersion"
-    implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
-    implementation "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
+
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/mifos/ops/zeebe/ZeebeOpsApplication.java
+++ b/src/main/java/org/mifos/ops/zeebe/ZeebeOpsApplication.java
@@ -31,8 +31,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -125,10 +123,10 @@ public class ZeebeOpsApplication {
         return new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
     }
 
-    @Bean
-    public ElasticsearchOperations elasticsearchTemplate() {
-        return new ElasticsearchRestTemplate(client());
-    }
+    // The ElasticsearchOperations/ElasticsearchRestTemplate bean was removed:
+    // no code consumed it, and the class no longer exists in Spring Data
+    // Elasticsearch 5 (Spring Boot 3). ES access goes through the
+    // RestHighLevelClient bean above.
 
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {

--- a/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
+++ b/src/main/java/org/mifos/ops/zeebe/camel/routes/OperationsRouteBuilder.java
@@ -1,9 +1,9 @@
 package org.mifos.ops.zeebe.camel.routes;
 
 import static org.mifos.ops.zeebe.zeebe.ZeebeMessages.OPERATOR_MANUAL_RECOVERY;
-import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.BPMN_PROCESS_ID;
-import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.PROCESS_DEFINITION_KEY;
-import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.PROCESS_INSTANCE_KEY;
+import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.BPMN_PROCESS_ID_PARAM;
+import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.PROCESS_DEFINITION_KEY_PARAM;
+import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.PROCESS_INSTANCE_KEY_PARAM;
 import static org.mifos.ops.zeebe.zeebe.ZeebeVariables.TRANSACTION_ID;
 
 import io.camunda.zeebe.client.ZeebeClient;
@@ -11,6 +11,8 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import jakarta.activation.DataHandler;
+import jakarta.mail.internet.MimeBodyPart;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -24,8 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.activation.DataHandler;
-import javax.mail.internet.MimeBodyPart;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.camunda.bpm.model.xml.instance.DomDocument;
@@ -257,12 +257,12 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
          *   ]
          * }
          */
-        from(String.format("rest:get:/channel/process/{%s}/task/", PROCESS_DEFINITION_KEY))
+        from(String.format("rest:get:/channel/process/{%s}/task/", PROCESS_DEFINITION_KEY_PARAM))
                 .id("get-executed-task")
                 .log(LoggingLevel.INFO, "## Fetching the executed task")
                 .process(exchange -> {
 
-                    Long processInstanceKey = exchange.getIn().getHeader(PROCESS_DEFINITION_KEY, Long.class);
+                    Long processInstanceKey = exchange.getIn().getHeader(PROCESS_DEFINITION_KEY_PARAM, Long.class);
 
                     TermsAggregationBuilder definitionNameAggregation = AggregationBuilders.terms("worker")
                             .field("value.worker")
@@ -301,7 +301,7 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
          * Get the process variables by process instance key
          *
          * demo url: /channel/process/variable/2251799813783649
-         * here [2251799813783649] is the value for path parameter [PROCESS_INSTANCE_KEY]
+         * here [2251799813783649] is the value for path parameter [processInstanceKey]
          *
          * example response: {
          * "isRtpRequest":"false",
@@ -309,12 +309,12 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
          * "originDate":"1633441154238"
          * }
          */
-        from(String.format("rest:get:/channel/process/variable/{%s}", PROCESS_INSTANCE_KEY))
+        from(String.format("rest:get:/channel/process/variable/{%s}", PROCESS_INSTANCE_KEY_PARAM))
                 .id("get-process-variable")
                 .log(LoggingLevel.INFO, "## Fetch process variable")
                 .process(exchange -> {
 
-                    Long processId = exchange.getIn().getHeader(PROCESS_INSTANCE_KEY, Long.class);
+                    Long processId = exchange.getIn().getHeader(PROCESS_INSTANCE_KEY_PARAM, Long.class);
 
                     TermsAggregationBuilder valueAgg = AggregationBuilders.terms("value")
                             .field("value.value")
@@ -363,12 +363,12 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
          *   "processVariables": {}
          * }
          */
-        from(String.format("rest:get:/channel/process/{%s}", PROCESS_DEFINITION_KEY))
+        from(String.format("rest:get:/channel/process/{%s}", PROCESS_DEFINITION_KEY_PARAM))
                 .id("get-process-variable-and-state")
                 .log(LoggingLevel.INFO, "## Fetch process variable and current state")
                 .process(exchange -> {
 
-                    Long processInstanceKey = exchange.getIn().getHeader(PROCESS_DEFINITION_KEY, Long.class);
+                    Long processInstanceKey = exchange.getIn().getHeader(PROCESS_DEFINITION_KEY_PARAM, Long.class);
 
                     try {
                         JSONObject processVariables = getProcessVariable(processInstanceKey);
@@ -458,21 +458,21 @@ public class OperationsRouteBuilder extends ErrorHandlerRouteBuilder {
          * response body: Null
          *
          * demo url: /channel/workflow/international_remittance_payer_process-ibank-usa
-         * Here [international_remittance_payer_process-ibank-usa] is the value of [BPMN_PROCESS_ID] path variable
+         * Here [international_remittance_payer_process-ibank-usa] is the value of [bpmnProcessId] path variable
          *
          */
-        from(String.format("rest:POST:/channel/workflow/{%s}", BPMN_PROCESS_ID))
+        from(String.format("rest:POST:/channel/workflow/{%s}", BPMN_PROCESS_ID_PARAM))
                 .id("workflow-start")
                 .log(LoggingLevel.INFO, "## Starting new workflow")
                 .process(e -> {
 
                     JSONObject variables = new JSONObject(e.getIn().getBody(String.class));
 
-                    e.getMessage().setBody(e.getIn().getHeader(BPMN_PROCESS_ID, String.class));
+                    e.getMessage().setBody(e.getIn().getHeader(BPMN_PROCESS_ID_PARAM, String.class));
 
 
                     ProcessInstanceEvent job = zeebeClient.newCreateInstanceCommand()
-                            .bpmnProcessId(e.getIn().getHeader(BPMN_PROCESS_ID, String.class))
+                            .bpmnProcessId(e.getIn().getHeader(BPMN_PROCESS_ID_PARAM, String.class))
                             .latestVersion()
                             .variables(variables)
                             .send()

--- a/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeVariables.java
+++ b/src/main/java/org/mifos/ops/zeebe/zeebe/ZeebeVariables.java
@@ -9,4 +9,11 @@ public final class ZeebeVariables {
     public static final String BPMN_PROCESS_ID = "BPMN_PROCESS_ID";
     public static final String PROCESS_INSTANCE_KEY = "PROCESS_INSTANCE_KEY";
     public static final String PROCESS_DEFINITION_KEY = "PROCESS_DEFINITION_KEY";
+
+    // REST path-parameter names. Camel 4 compiles {placeholder} into a Java
+    // named capturing group, and Java group names cannot contain underscores,
+    // so the *_KEY/_ID constants above cannot be used in route templates.
+    public static final String BPMN_PROCESS_ID_PARAM = "bpmnProcessId";
+    public static final String PROCESS_INSTANCE_KEY_PARAM = "processInstanceKey";
+    public static final String PROCESS_DEFINITION_KEY_PARAM = "processDefinitionKey";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,4 +52,11 @@ management:
         enabled: true
       readiness:
         enabled: true
+  health:
+    # Spring Boot 3 auto-configures an Elasticsearch health indicator pointing at the default
+    # localhost:9200, which isn't the ES client this connector uses (it has its own /es/health
+    # Camel route). That default probe fails (Connection refused) and drags the aggregate
+    # /actuator/health to DOWN, so disable it. The k8s liveness/readiness groups are unaffected.
+    elasticsearch:
+      enabled: false
 


### PR DESCRIPTION
## What

Migrate this connector to **Spring Boot 3.4 / JDK 21 / Jakarta EE 10 / Apache Camel 4**. All versions come from the Mifos Platform BOM via `enforcedPlatform(...)` instead of being pinned by hand.

Surgical migration: `javax.*` -> `jakarta.*`, versions moved to the BOM, and the minimum changes needed to compile and run. No feature work, no refactoring.

## Main changes

- `build.gradle`: Spring Boot plugin -> 3.4, `io.spring.dependency-management`, `enforcedPlatform('org.mifos.platform:mifos-platform-bom:1.0.0-SNAPSHOT')`; hand-pinned versions removed. `ph-ee-connector-common` -> `2.0.0-SNAPSHOT` where used.
- `javax.*` -> `jakarta.*` imports.
- Dockerfile base image -> `21-jre`.
- javax.mail->Angus; Camel 4 REST path-params renamed (Camel 4 forbids underscores in named groups). Config note: disabled the auto-configured Elasticsearch health indicator (SB3 pointed it at localhost:9200; the app uses its own ES client via a Camel route). Validated on gazelle: operational API works (start/cancel a workflow).

## Heads-up for review

- Depends on the Mifos Platform BOM (and `ph-ee-connector-common:2.0.0-SNAPSHOT` where used), **not yet published to the official Mifos JFrog**. Until then it builds against a local JFrog, so CI here will not pass until those are published upstream.

Draft - opening so we can review it together.
